### PR TITLE
Changing the colour of the attachment icon

### DIFF
--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -272,3 +272,20 @@ a {
 .nylas-editable-list .items-wrapper {
     background-color: #3f3b39;
 }
+
+
+
+//Changing the colour of the attachment icon
+.thread-icon:not(.thread-icon-unread):not(.thread-icon-star) {
+-webkit-filter: invert(100%);
+}
+img.content-dark {
+-webkit-filter: invert(100%);
+}
+img.content-light {
+-webkit-filter: invert(100%);
+}
+
+.mail-label {
+-webkit-filter: contrast(110%) brightness(85%);
+}


### PR DESCRIPTION
The original attachment icon was too dark and therefore invisible in the theme background colour. The code additions should improve its visibility.